### PR TITLE
issue #45: Use alternative delimiter to make pgn json-compliant

### DIFF
--- a/app/common/game_parser.py
+++ b/app/common/game_parser.py
@@ -7,11 +7,11 @@ class GameParser:
     Populate the Game table with parsed games.
     Unparse games and return them as pgns or strings."""
 
-    def __init__(self, pgn_string=None, game_id=None, verbose=False):
+    def __init__(self, pgn_string=None, game_id=None, verbose=False, delimiter='|'):
         """Init the GameParser either with a pgn string or with a game id.
         Game id should correspond with the Game.id in the database."""
 
-        self.pgn = pgn_string
+        self.pgn = '\n'.join(pgn_string.split(delimiter))
         self.game_id = game_id
         self.parsed_games = pgn.loads(self.pgn) if self.pgn else None
         self.verbose = verbose
@@ -35,7 +35,7 @@ class GameParser:
     def format_game(self, game, return_type='pgn'):
         """Formats a game model into a pgn or dictionary"""
 
-        players = self.__unparse_players_with_color(players=game.players, 
+        players = self.__unparse_players_with_color(players=game.players,
                                                     game_id=game.id)
         # Preparing the game object for a pgn dumps
         game.white = players['white'].full_name()
@@ -86,7 +86,7 @@ class GameParser:
                 self.__print("Adding game {} vs {} {}".format(game.white, game.black, game.date))
 
                 # Returns dict like: {white: <id>, black: <id>}
-                db_player_ids = self.__add_players(white=game.white, 
+                db_player_ids = self.__add_players(white=game.white,
                                                     black=game.black)
                 db_game_id = self.__add_game(game)
                 self.__add_pairings(game_id=db_game_id,
@@ -98,7 +98,7 @@ class GameParser:
         games = models.Game.query.all()
         if any(request_args):
             games = list(filter(lambda g: self.__game_match(g, request_args), games))
-        
+
         return games
 
     def get_game(self, id=1):
@@ -205,7 +205,7 @@ class GameParser:
         name_array = name_string.split(',')
         name_dict['first_name'] = name_array[1].strip() if len(name_array) > 1 else ''
         name_dict['last_name'] = name_array[0].strip()
-        return name_dict 
+        return name_dict
 
     def __add_pairings(self, game_id, player_ids):
         """Receives a game_id and a dict with player ids,
@@ -214,7 +214,7 @@ class GameParser:
         black_pairing = models.Pairing(game_id=game_id,
                                         player_id=player_ids['black'],
                                         color='black')
-        white_pairing = models.Pairing(game_id=game_id, 
+        white_pairing = models.Pairing(game_id=game_id,
                                         player_id = player_ids['white'],
                                         color='white')
         db.session.add(black_pairing)

--- a/app/common/game_parser.py
+++ b/app/common/game_parser.py
@@ -7,11 +7,13 @@ class GameParser:
     Populate the Game table with parsed games.
     Unparse games and return them as pgns or strings."""
 
-    def __init__(self, pgn_string=None, game_id=None, verbose=False, delimiter='|'):
+    def __init__(self, pgn_string=None, game_id=None, verbose=False, delimiter=None):
         """Init the GameParser either with a pgn string or with a game id.
         Game id should correspond with the Game.id in the database."""
-
-        self.pgn = '\n'.join(pgn_string.split(delimiter))
+        if pgn_string:
+            self.pgn = '\n'.join(pgn_string.split(delimiter))
+        else:
+            self.pgn = None
         self.game_id = game_id
         self.parsed_games = pgn.loads(self.pgn) if self.pgn else None
         self.verbose = verbose

--- a/app/resources/games.py
+++ b/app/resources/games.py
@@ -14,11 +14,11 @@ parser.add_argument('format', type=str,
     choices=("json", "pgn"),
     case_sensitive=False,
     help='Valid formats: json (default) or pgn')
-parser.add_argument('name', type=str, 
+parser.add_argument('name', type=str,
     case_sensitive=False,
     store_missing=False,
     help='Name of player')
-parser.add_argument('eco', type=str, 
+parser.add_argument('eco', type=str,
     case_sensitive=False,
     store_missing=False,
     help='Encyclopedia of Chess Opening (ECO) Codes')
@@ -55,10 +55,11 @@ class GameList(Resource):
         # NOTE(for deployment, an authentication strategy for this endpoint is highly recommended)
 
         request_params = request.get_json()
+        delimiter = request_params['delimiter']
         data = request_params['data']
 
         if 'pgn' in data:
-            game_parser = GameParser(pgn_string=data['pgn'])
+            game_parser = GameParser(pgn_string=data['pgn'], delimiter=delimiter)
             game_parser.add_games()
 
             return json.dumps({'status': 200, 'message': 'Games Successfully Parsed.'})

--- a/runserver.py
+++ b/runserver.py
@@ -1,4 +1,2 @@
 from app import app
-
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+app.run(debug=True)

--- a/runserver.py
+++ b/runserver.py
@@ -1,2 +1,4 @@
 from app import app
-app.run(debug=True)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
Sorry, my IDE is set up to drop spaces at the end of lines and create one blank line at the end of files. It's a requirement for the work team I'm on.

Anyway, I tried this out. 
Request:
```
{
    "delimiter": "|",
    "data": {
        "pgn": "[Event \"Live Chess\"]|[Site \"Chess.com\"]|[Date \"2021.03.18\"]|[Round \"-\"]|[White \"Doctorgt3\"]|[Black \"socal_dave\"]|[Result \"1-0\"]|[WhiteElo \"1267\"]|[BlackElo \"1240\"]|[TimeControl \"120+1\"]|[EndTime \"21:34:27 PDT\"]|[Termination \"Doctorgt3 won by resignation\"]|[ECO \"C31\"]|1. e4 e5 2. f4 d5 3. Nc3 c6 4. d4 exf4 5. Bxf4 Nf6 6. Bxb8 Rxb8 7. e5 Nd7 8. Nf3  Bb4 9. Qd3 O-O 10. O-O-O b5 11. a3 Bxa3 12. bxa3 a5 13. Kd2 b4 14. axb4 Rxb4 15.  Be2 Nb6 16. Rb1 Nc4+ 17. Ke1 Nb2 18. Qe3 Bf5 19. Na2 Bxc2 20. Nxb4 Bxb1 21. Nxc6  Qb6 22. Ne7+ Kh8 23. Kf2 a4 24. Rxb1 1-0"
    }
}
```
Response:
```
"{\"status\": 200, \"message\": \"Games Successfully Parsed.\"}"
```